### PR TITLE
chore: make lowercase identifier

### DIFF
--- a/config/_default/menu.en.toml
+++ b/config/_default/menu.en.toml
@@ -1,5 +1,5 @@
 [[main]]
-    identifier = "Effective Gnops"
+    identifier = "Effective gnops"
     name = "effective-gnops"
     pageRef = "effective-gnops/"
     weight = 1


### PR DESCRIPTION
## Description

This PR makes the `Effective Gnops` identifier lowercase, to `Effective gnops`