### PR TITLE
fix: validator proposal

### DIFF
--- a/content/english/articles/guides/become-testnet-validator/index.md
+++ b/content/english/articles/guides/become-testnet-validator/index.md
@@ -108,10 +108,10 @@ import (
 )
 
 func main() {
-    address := std.Address("...") // <--- the valoper profile address
+	addr := std.Address("...") // <--- the valoper profile address
 
 	// Create a proposal to add a new validator to the valset
-	pr := proposal.NewValidatorProposalRequest(cross, address)
+	pr := proposal.NewValidatorProposalRequest(cross, addr)
 
 	// Create the proposal
 	dao.MustCreateProposal(cross, pr)


### PR DESCRIPTION
copying the validator proposal result in an error about shadowing the `address` builtin, this corrects it by renaming the variable to `addr`