### PR TITLE
chore: Add -skip-genesis-sig-verification to gnoland start examples

### DIFF
--- a/content/english/articles/guides/local-chain/index.md
+++ b/content/english/articles/guides/local-chain/index.md
@@ -54,7 +54,7 @@ And finally, run it with `./build gnoland`.
 You can start a Gno blockchain node with the default configuration by running the following command:
 
 ```bash
-gnoland start --lazy
+gnoland start --lazy -skip-genesis-sig-verification
 ```
 
 The command will trigger a chain initialization process (if you haven't run the node before), and start the Gno node,


### PR DESCRIPTION
At the moment, `gnoland start -lazy` crashes, as described in issue https://github.com/gnolang/gno/issues/4476 . Until that is fixed, we update the examples to include `-skip-genesis-sig-verification` .

See also https://github.com/gnolang/gno/pull/4614