### PR TITLE
docs: update become-testnet-validator guide for test13

### DIFF
--- a/content/english/articles/guides/become-testnet-validator/index.md
+++ b/content/english/articles/guides/become-testnet-validator/index.md
@@ -138,14 +138,14 @@ import (
 	"gno.land/r/gov/dao"
 )
 
-func main() {
+func main(cur realm) {
 	addr := address("...") // <--- the operator address (valoper profile key)
 
 	// Create a proposal to add a new validator to the valset
-	pr := proposal.NewValidatorProposalRequest(cross, addr)
+	pr := proposal.NewValidatorProposalRequest(cross(cur), addr)
 
 	// Create the proposal
-	dao.MustCreateProposal(cross, pr)
+	dao.MustCreateProposal(cross(cur), pr)
 }
 ```
 
@@ -180,8 +180,8 @@ import (
 	"gno.land/r/gov/dao"
 )
 
-func main() {
-	dao.VoteOnProposal(cross, dao.VoteRequest{
+func main(cur realm) {
+	dao.VoteOnProposal(cross(cur), dao.VoteRequest{
 		Option:     dao.YesVote,
 		ProposalID: dao.ProposalID(0), // replace with your proposal ID
 	})

--- a/content/english/articles/guides/become-testnet-validator/index.md
+++ b/content/english/articles/guides/become-testnet-validator/index.md
@@ -181,10 +181,8 @@ import (
 )
 
 func main(cur realm) {
-	dao.VoteOnProposal(cross(cur), dao.VoteRequest{
-		Option:     dao.YesVote,
-		ProposalID: dao.ProposalID(0), // replace with your proposal ID
-	})
+	// Replace 0 with your proposal ID
+	dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, dao.ProposalID(0)))
 }
 ```
 

--- a/content/english/articles/guides/become-testnet-validator/index.md
+++ b/content/english/articles/guides/become-testnet-validator/index.md
@@ -36,12 +36,15 @@ why you should be accepted as a validator.
 Be sure to answer the following questions in the description. This is an example of the details you should provide in
 your description:
 
-1. **Validator Name** – Your unique identifier.
+1. **Validator Name** – The name of your validator.
 2. **Networks You Are Currently Validating** – Include your total Assets Under Management (AuM).
-3. **Links to Your Digital Presence** – Website, social media, etc.
+3. **Links to Your Digital Presence** – Website, social media, etc. Please include your Discord handle so you can be
+   added to our main comms channel, the gno.land valoper Discord channel.
 4. **Contact Details** – How others can reach you.
 5. **Why You Are Interested in Validating on gno.land** – Your motivation and goals.
 6. **Contributions to gno.land** – Past contributions or plans for future contributions.
+7. **Your Node Architecture** – For example, do you run sentry nodes to shield your validator?
+8. **Backup Strategy** – How do you handle backups of your keys and node data?
 
 _Note:_ You can update your `Valoper` profile later using the `Update` helper functions such as `UpdateDescription`.
 

--- a/content/english/articles/guides/become-testnet-validator/index.md
+++ b/content/english/articles/guides/become-testnet-validator/index.md
@@ -58,18 +58,18 @@ gnokey maketx call \
     -gas-fee 20000ugnot \
     -gas-wanted 20_000_000 \
     -broadcast \
-    -chainid "test11" \
+    -chainid "test-13" \
     -args "<moniker>" \
     -args "<description>" \
     -args "<server_type>" \
-    -args "<validator_address>" \
-    -args "<pub_key_bech32>" \
-    -remote "https://rpc.test11.testnets.gno.land:443" \
+    -args "<operator_address>" \
+    -args "<consensus_pub_key>" \
+    -remote "https://rpc.test13.testnets.gno.land:443" \
     <key-name>
 ```
 
-Replace `<moniker>`, `<description>`, `<server_type>`, `<validator_address>`, `<pub_key_bech32>`, and `<key-name>` with
-your actual values.
+Replace `<moniker>`, `<description>`, `<server_type>`, `<operator_address>`, `<consensus_pub_key>`, and `<key-name>`
+with your actual values.
 
 `<server_type>` must be one of:
 
@@ -77,9 +77,32 @@ your actual values.
 - `on-prem`
 - `data-center`
 
+The last two arguments are distinct and must not be confused:
+
+- **`<operator_address>`** is your **operator** account address (`g1...`): the stable identity and profile key. It must
+  match the address of the `<key-name>` you broadcast with — the realm enforces that the caller equals the operator
+  address.
+- **`<consensus_pub_key>`** is your validator node's **consensus signing public key** (`gpub1...`). The realm derives the
+  signing address from it, so you only supply the public key, not the address.
+
 The `chainid` and `remote` values might change. Please check the latest information.
 
-To fetch the validator address and bech32 representation of the public key, you can run:
+To fetch your operator address, list your local keys with `gnokey`:
+
+```shell
+gnokey list
+```
+
+Example output:
+
+```shell
+0. test1 (local) - addr: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 pub: gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj, path: <nil>
+```
+
+The `addr` value (`g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`) is your `<operator_address>`, and `test1` is the matching
+`<key-name>` you broadcast with.
+
+To fetch your validator node's consensus public key, you can run:
 
 ```shell
 gnoland secrets get validator_key -data-dir gnoland-data
@@ -95,6 +118,9 @@ Example output:
     "pub_key": "gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zpj3xqx6w4nvy209e28trenv3relp04jt37p0rg2pn4hyy4k0uf2vgexegj"
 }
 ```
+
+Use the `pub_key` value above as `<consensus_pub_key>`. The `address` shown here is the node's signing address — it is
+**not** the operator address and should not be used as `<operator_address>`.
 
 ## Step 3: Submitting the Proposal
 
@@ -113,7 +139,7 @@ import (
 )
 
 func main() {
-	addr := address("...") // <--- the valoper profile address
+	addr := address("...") // <--- the operator address (valoper profile key)
 
 	// Create a proposal to add a new validator to the valset
 	pr := proposal.NewValidatorProposalRequest(cross, addr)
@@ -130,8 +156,8 @@ gnokey maketx run \
   -gas-fee 31000ugnot \
   -gas-wanted 30_000_000 \
   -broadcast \
-  -chainid "test11" \
-  -remote "https://rpc.test11.testnets.gno.land:443" \
+  -chainid "test-13" \
+  -remote "https://rpc.test13.testnets.gno.land:443" \
   <key-name> \
   ./proposal.gno
 ```
@@ -168,8 +194,8 @@ gnokey maketx run \
   -gas-fee 18000ugnot \
   -gas-wanted 18_000_000 \
   -broadcast \
-  -chainid "test11" \
-  -remote "https://rpc.test11.testnets.gno.land:443" \
+  -chainid "test-13" \
+  -remote "https://rpc.test13.testnets.gno.land:443" \
   <key-name> \
   ./vote_proposal.gno
 ```

--- a/content/english/articles/guides/become-testnet-validator/index.md
+++ b/content/english/articles/guides/become-testnet-validator/index.md
@@ -124,10 +124,10 @@ Use the `pub_key` value above as `<consensus_pub_key>`. The `address` shown here
 
 ## Step 3: Submitting the Proposal
 
-Once your `Valoper` profile is ready, you need to notify GovDAO; only a GovDAO member can submit a proposal to add you
-to the validator set. The fastest way is to reach out on [Discord](https://discord.gg/gnoland).
+> **This step is for GovDAO members only.** Only a GovDAO member can submit a proposal to add a validator to the
+> validator set.
 
-If you are a GovDAO member, you can nominate yourself by calling `maketx run` on the following script:
+Once your `Valoper` profile is ready, a GovDAO member can nominate it by calling `maketx run` on the following script:
 
 ```go
 // proposal.gno

--- a/content/english/articles/guides/become-testnet-validator/index.md
+++ b/content/english/articles/guides/become-testnet-validator/index.md
@@ -43,8 +43,6 @@ your description:
 4. **Contact Details** – How others can reach you.
 5. **Why You Are Interested in Validating on gno.land** – Your motivation and goals.
 6. **Contributions to gno.land** – Past contributions or plans for future contributions.
-7. **Your Node Architecture** – For example, do you run sentry nodes to shield your validator?
-8. **Backup Strategy** – How do you handle backups of your keys and node data?
 
 _Note:_ You can update your `Valoper` profile later using the `Update` helper functions such as `UpdateDescription`.
 

--- a/content/english/articles/guides/become-testnet-validator/index.md
+++ b/content/english/articles/guides/become-testnet-validator/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Road to Validation: How to become a testnet validator"
-publishDate: 2025-03-14T08:00:00-01:00
+publishDate: 2026-06-23T08:00:00-01:00
 translationKey: "bootnodes-persistent-peers"
 tags: ["validator", "valopers", "testnet", "onboarding"]
 level: Intermediate

--- a/content/english/articles/guides/become-testnet-validator/index.md
+++ b/content/english/articles/guides/become-testnet-validator/index.md
@@ -13,8 +13,8 @@ summary: "This gives a set of information on onboarding a validator node: how to
 ## Overview
 
 Validators on **gno.land** are expected to demonstrate their technical expertise and alignment with the project by
-making continuous and meaningful contributions. **gno.land** abstracts validator management into the `r/sys/vals` realm
-as a form of a smart contract for modularity.
+making continuous and meaningful contributions. **gno.land** abstracts validator management into the
+`r/sys/validators/v3` realm as a form of a smart contract for modularity.
 
 This guide walks you through the process of registering your validator node into the validator set with a
 smart-contract. It assumes that you already have an operational validator node running on the testnet, before submitting
@@ -55,9 +55,8 @@ Once your `Valoper` profile is prepared, register it using `gnokey` with the fol
 gnokey maketx call \
     -pkgpath "gno.land/r/gnops/valopers" \
     -func "Register" \
-    -gas-fee 20000ugnot \
-    -gas-wanted 20_000_000 \
-    -broadcast \
+    -gas-fee 1000000ugnot \
+    -gas-wanted 50_000_000 \
     -chainid "test-13" \
     -args "<moniker>" \
     -args "<description>" \
@@ -155,7 +154,6 @@ Run the command using:
 gnokey maketx run \
   -gas-fee 31000ugnot \
   -gas-wanted 30_000_000 \
-  -broadcast \
   -chainid "test-13" \
   -remote "https://rpc.test13.testnets.gno.land:443" \
   <key-name> \
@@ -193,7 +191,6 @@ func main() {
 gnokey maketx run \
   -gas-fee 18000ugnot \
   -gas-wanted 18_000_000 \
-  -broadcast \
   -chainid "test-13" \
   -remote "https://rpc.test13.testnets.gno.land:443" \
   <key-name> \


### PR DESCRIPTION
## Summary

Refreshes the **Road to Validation: How to become a testnet validator** guide for the **test13** testnet. The guide had drifted since test11: stale endpoints, outdated `gnokey` flags, an old realm reference, and `maketx run` scripts that no longer compile under the current gno crossing convention. All commands and scripts were verified against the live `r/gnops/valopers` realm, the `chain/test13` source, and a local `gnodev` run-through.

## Changes

### Endpoints (test11 → test13)
- `chainid` → `test-13` and `remote` → `https://rpc.test13.testnets.gno.land:443` across the register, proposal, and vote commands.

### `Register` arguments — operator address vs. consensus key
- Renamed the 4th/5th args to `<operator_address>` and `<consensus_pub_key>` and documented the distinction, matching the realm:
  - **`<operator_address>`** (`g1...`) — the stable profile identity; the realm enforces `OriginCaller == addr`, so it must match the key you broadcast with.
  - **`<consensus_pub_key>`** (`gpub1...`) — the node's consensus signing key; the realm derives the signing address from it.
- Added a `gnokey list` step (with example output) to get the operator address, and clarified that `gnoland secrets get validator_key` provides the consensus pubkey — its `address` field is the signing address, **not** the operator address.

### `gnokey` / realm API refresh
- Fixed stale realm reference in the Overview: `r/sys/vals` → `r/sys/validators/v3`.
- Dropped the redundant `-broadcast` flag (now defaults to `true`).
- Aligned the `Register` gas with the documented test13 values (`1000000ugnot` / `50_000_000`).

### `maketx run` scripts (Steps 3 & 4) — new crossing convention
- `func main()` → `func main(cur realm)`, and crossing calls now use `cross(cur)` instead of the bare `cross` token (the old form fails type-checking on current gno).
- Vote script now builds the request via `dao.NewVoteRequest(...)` instead of a `dao.VoteRequest{}` literal — a struct literal of a dao-owned type cannot be allocated in the `run` realm.

### Editorial
- Step 1 description checklist: added the Discord-handle note to "Digital Presence" (now requested by the on-chain instructions).
- Step 3: marked as **GovDAO-members-only** and removed the "reach out on Discord" line.
- Bumped `publishDate`.

## References
- test13 VALIDATOR.md: https://github.com/gnolang/gno/blob/chain/test13/misc/deployments/test13.gno.land/VALIDATOR.md
- Realm: https://test13.testnets.gno.land/r/gnops/valopers
